### PR TITLE
Moved to classes and minor refactoring of data storage

### DIFF
--- a/Watson/App.config
+++ b/Watson/App.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup>
 </configuration>

--- a/Watson/Info.cs
+++ b/Watson/Info.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Watson
+{
+    public static class Info
+    {
+        public static void PrintLogo()
+        {
+            Console.WriteLine("  __    __      _                   ");
+            Console.WriteLine(" / / /\\ \\ \\__ _| |_ ___  ___  _ __  ");
+            Console.WriteLine(" \\ \\/  \\/ / _` | __/ __|/ _ \\| '_ \\ ");
+            Console.WriteLine("  \\  /\\  / (_| | |_\\__ \\ (_) | | | |");
+            Console.WriteLine("   \\/  \\/ \\__,_|\\__|___/\\___/|_| |_|");
+            Console.WriteLine("                                   ");
+            Console.WriteLine("                           v0.1    ");
+            Console.WriteLine("                                   ");
+            Console.WriteLine("                  Sherlock sucks...");
+            Console.WriteLine("                   @_RastaMouse\r\n");
+        }
+    }
+}

--- a/Watson/Program.cs
+++ b/Watson/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Diagnostics;
-using System.Management;
-using System.Data;
+using Watson.SuspectFiles;
+
 
 /*
  * 
@@ -28,651 +27,69 @@ namespace Watson
 {
     public static class Program
     {
-
-        public static void PrintLogo()
-        {
-            Console.WriteLine("  __    __      _                   ");
-            Console.WriteLine(" / / /\\ \\ \\__ _| |_ ___  ___  _ __  ");
-            Console.WriteLine(" \\ \\/  \\/ / _` | __/ __|/ _ \\| '_ \\ ");
-            Console.WriteLine("  \\  /\\  / (_| | |_\\__ \\ (_) | | | |");
-            Console.WriteLine("   \\/  \\/ \\__,_|\\__|___/\\___/|_| |_|");
-            Console.WriteLine("                                   ");
-            Console.WriteLine("                           v0.1    ");
-            Console.WriteLine("                                   ");
-            Console.WriteLine("                  Sherlock sucks...");
-            Console.WriteLine("                   @_RastaMouse\r\n");
-        }
-
-        public static DataTable GetTable()
-        {
-            DataTable dataTable = new DataTable();
-            dataTable.Columns.Add("Name", typeof(string));
-            dataTable.Columns.Add("Description", typeof(string));
-            dataTable.Columns.Add("Exploit", typeof(string));
-            dataTable.Columns.Add("Vulnerable", typeof(bool));
-            dataTable.Columns.Add("Notes", typeof(string));
-
-            dataTable.Rows.Add("MS10-015", "Windows SYSTEM Escalation via KiTrap0D.", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms10_015_kitrap0d.rb", false, "None.");
-            dataTable.Rows.Add("MS10-073", "Kernel-mode drivers load unspecified keyboard layers improperly, which result in arbitrary code execution in the kernel.", "https://www.exploit-db.com/exploits/36327/", false, "None.");
-            dataTable.Rows.Add("MS10-092", "When processing task files, the Windows Task Scheduler only uses a CRC32 checksum to validate that the file has not been tampered with.Also, In a default configuration, normal users can read and write the task files that they have created.By modifying the task file and creating a CRC32 collision, an attacker can execute arbitrary commands with SYSTEM privileges.", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms10_092_schelevator.rb", false, "None.");
-            //
-            dataTable.Rows.Add("MS11-046", "The Ancillary Function Driver (AFD) in afd.sys does not properly validate user-mode input, which allows local users to elevate privileges.", "https://www.exploit-db.com/exploits/40564/", false, "None.");
-            dataTable.Rows.Add("MS11-080", "An EoP exists due to a flaw in the AfdJoinLeaf function of the afd.sys driver, allowing data overwrite in kernel space.", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb", false, "None.");
-            //
-            dataTable.Rows.Add("MS12-042", "An EoP exists due to the way the Windows User Mode Scheduler handles system requests, which can be exploited to execute arbitrary code in kernel mode.", "https://www.exploit-db.com/exploits/20861/", false, "None.");
-            //
-            dataTable.Rows.Add("MS13-005", "Due to a problem with isolating window broadcast messages in the Windows kernel, an attacker can broadcast commands from a lower Integrity Level process to a higher Integrity Level process, thereby effecting a privilege escalation.", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb", false, "None.");
-            dataTable.Rows.Add("MS13-053", "An EoP exists due to a kernel pool overflow in Win32k.", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms13_053_schlamperei.rb", false, "None.");
-            dataTable.Rows.Add("MS13-081", "An EoP exists in win32k.sys where under specific conditions TrackPopupMenuEx will pass a NULL pointer to the MNEndMenuState procedure.", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms13_081_track_popup_menu.rb", false, "None.");
-            //
-            dataTable.Rows.Add("MS14-058", "An EoP exists due to a NULL Pointer Dereference in win32k.sys, triggered through the use of TrackPopupMenu.", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms14_058_track_popup_menu.rb", false, "None.");
-            //
-            dataTable.Rows.Add("MS15-051", "An EoP exists due to improper object handling in the win32k.sys kernel mode driver.", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms15_051_client_copy_image.rb", false, "None.");
-            dataTable.Rows.Add("MS15-076", "Local DCOM DCE/RPC connections can be reflected back to a listening TCP socket allowing access to an NTLM authentication challenge for LocalSystem, which can be replayed to the local DCOM activation service to elevate privileges.", "https://www.exploit-db.com/exploits/37768/", false, "None.");
-            dataTable.Rows.Add("MS15-078", "An EoP exists due to a pool based buffer overflow in the atmfd.dll driver when parsing a malformed font.", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms15_078_atmfd_bof.rb", false, "None.");
-            //
-            dataTable.Rows.Add("MS16-014", "An EoP exists when the Windows kernel improperly handles objects in memory.", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms16_014_wmi_recv_notif.rb", false, "None.");
-            dataTable.Rows.Add("MS16-016", "An EoP exists in the Microsoft Web Distributed Authoring and Versioning (WebDAV) client when WebDAV improperly validates input.", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms16_016_webdav.rb", false, "None.");
-            dataTable.Rows.Add("MS16-032", "An EoP exists due to a lack of sanitization of standard handles in Windows' Secondary Logon Service.", "https://github.com/FuzzySecurity/PowerShell-Suite/blob/master/Invoke-MS16-032.ps1", false, "None.");
-            dataTable.Rows.Add("MS16-034", "An EoP exist when the Windows kernel-mode driver fails to properly handle objects in memory.", "https://github.com/SecWiki/windows-kernel-exploits/tree/master/MS16-034", false, "None.");
-            dataTable.Rows.Add("MS16-039", "An EoP exist when the Windows kernel-mode driver fails to properly handle objects in memory.", "https://www.exploit-db.com/exploits/44480/", false, "Exploit is for Windows 7 x86.");
-            dataTable.Rows.Add("MS16-072", "This vulnerability allows an attacker to create/modify local Administrator account through a fake Domain Controller by creating User Configuration Group Policies.", "https://www.exploit-db.com/exploits/40219/", false, "Good luck with this one...");
-            dataTable.Rows.Add("MS16-111", "The NtLoadKeyEx system call allows an unprivileged user to load registry hives outside of the \\Registry\\A hidden attachment point which can be used to elevate privileges.", "https://www.exploit-db.com/exploits/40429/", false, "None.");
-            dataTable.Rows.Add("MS16-123", "The DFS Client driver and running by default insecurely creates and deletes drive letter symbolic links in the current user context, leading to EoP.", "https://www.exploit-db.com/exploits/40572/", false, "Exploit requires weaponisation.");
-            dataTable.Rows.Add("MS16-125", "The fix for CVE-2016-3231 is insufficient to prevent a normal user specifying an insecure agent path leading to arbitrary DLL loading at system privileges.", "https://www.exploit-db.com/exploits/40562/", false, "Exploit requires a DLL to load.");
-            dataTable.Rows.Add("MS16-135", "An EoP exists when the Windows kernel-mode driver fails to properly handle objects in memory.", "https://github.com/FuzzySecurity/PSKernel-Primitives/tree/master/Sample-Exploits/MS16-135", false, "None.");
-            dataTable.Rows.Add("MS16-138", "The VHDMP driver doesn’t safely create files related to Resilient Change Tracking leading to arbitrary file overwrites under user control, leading to EoP.", "https://www.exploit-db.com/exploits/40763/", false, "Exploit requires weaponisation.");
-            //
-            dataTable.Rows.Add("MS17-012", "When activating an object using the session moniker the DCOM activator doesn’t check if the current user has permission, allowing a user to start an arbitrary process in another logged on user's session.", "https://www.exploit-db.com/exploits/41607/", false, "None.");
-            dataTable.Rows.Add("MS17-017", "GDI Palette Objects EoP.", "https://www.exploit-db.com/exploits/42432/", false, "Exploit is for Windows 7 x86 only");
-            dataTable.Rows.Add("CVE-2017-0263", "An EoP exists in Windows when the Windows kernel-mode driver fails to properly handle objects in memory.", "https://www.exploit-db.com/exploits/44478/", false, "Exploit is for Windows 7 x86.");
-            //
-            dataTable.Rows.Add("CVE-2018-8897", "An EoP exists when the Windows kernel fails to properly handle objects in memory.", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/mov_ss.rb", false, "May not work on all hypervisors.");
-            dataTable.Rows.Add("CVE-2018-0952", "An EoP exists when Diagnostics Hub Standard Collector allows file creation in arbitrary locations. ", "https://www.exploit-db.com/exploits/45244/", false, "None");
-            dataTable.Rows.Add("CVE-2018-8440", "An EoP exists when Windows improperly handles calls to Advanced Local Procedure Call (ALPC).", "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/alpc_taskscheduler.rb", false, "None.");
-
-            return dataTable;
-        }
-
-        public static void UpdateDataTable(string Name, DataTable Table)
-        {
-            foreach (DataRow row in Table.Rows)
-            {
-                if ((string) row["Name"] == Name)
-                {
-                    row["Vulnerable"] = true;
-                }
-            }
-        }
-
-        public static string GetOSBuildNumber()
-        {
-            string result = string.Empty;
-
-            ManagementObjectSearcher osData = new ManagementObjectSearcher("SELECT * FROM Win32_OperatingSystem");
-
-            foreach (ManagementObject os in osData.Get())
-            {
-                result = os["BuildNumber"].ToString();
-            }
-
-            return result;
-        }
-
-        public static FileVersionInfo GetFileVersionInfo(string FilePath)
-        {
-            FileVersionInfo result = FileVersionInfo.GetVersionInfo(FilePath);
-            return result;
-        }
-
-        public static UInt16 GetCPUArchitecutre()
-        {
-            // bool result = System.Environment.Is64BitOperatingSystem;  // Not available in .NET <4
-
-            UInt16 result = 0;
-
-            ManagementObjectSearcher cpuData = new ManagementObjectSearcher("select AddressWidth from Win32_Processor");
-
-            foreach (ManagementObject cpu in cpuData.Get())
-            {
-                result = (UInt16) cpu["AddressWidth"];
-            }
-
-            return result;
-
-        }
-
-        public static int GetProcessArchitecture()
-        {
-            // bool result = System.Environment.Is64BitProcess;  // Not available in .NET <4
-
-            int result = IntPtr.Size;
-            return result;
-        }
-
-        public static int GetProcessorCoreCount()
-        {
-            int result = System.Environment.ProcessorCount;
-            return result;
-        }
-
-        public static string GetWinPath(UInt16 cpuAddrWidth, int procIntPtr)
-        {
-            if ((cpuAddrWidth == 64 && procIntPtr == 8) || (cpuAddrWidth == 32 && procIntPtr == 4))
-            {
-                string result = "C:\\WINDOWS\\System32";
-                return result;
-            }
-            else
-            {
-                string result = "C:\\WINDOWS\\Sysnative";
-                return result;
-            }
-
-        }
-
         public static void Main(string[] args)
         {
+            Info.PrintLogo();
 
-            PrintLogo();
-
-            // collect some info
-
-            string osBuild = GetOSBuildNumber();
-            Console.WriteLine(" [*] OS Build number: {0}", osBuild);
-
-            UInt16 cpuAddrWidth = GetCPUArchitecutre();
-            Console.WriteLine(" [*] CPU Address Width: {0}", cpuAddrWidth);
-
-            int procIntPtr = GetProcessArchitecture();
-            Console.WriteLine(" [*] Processs IntPtr Size: {0}", procIntPtr);
-
-            string winPath = GetWinPath(cpuAddrWidth, procIntPtr);
-            Console.WriteLine(" [*] Using Windows path: {0}", winPath);
-
-            int cpuCount = GetProcessorCoreCount();
+            var sysInfo = SystemInfo.Collect();
+            SystemInfoHelpers.PrintInfo(sysInfo);
 
             Console.WriteLine();
 
             // let the fun begin
 
-            DataTable vulnTable = GetTable();
+            var vulnerabilities = new VulnerabilityCollection();
 
             // ntoskrnl.exe
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\ntoskrnl.exe");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "6000":
-                        if (version < 16973) { UpdateDataTable("MS10-015", vulnTable); }
-                        break;
-
-                    case "6001":
-                        if (version < 18377) { UpdateDataTable("MS10-015", vulnTable); }
-                        break;
-
-                    case "6002":
-                        if (version < 18160) { UpdateDataTable("MS10-015", vulnTable); }
-                        break;
-
-                    case "10240":
-                        if (version < 17113) { UpdateDataTable("MS16-111", vulnTable); }
-                        if (version < 17184)
-                        {
-                            UpdateDataTable("MS16-135", vulnTable);
-                            UpdateDataTable("MS16-138", vulnTable);
-                        }
-                        if (version < 17946) { UpdateDataTable("CVE-2018-0952", vulnTable); }
-                        if (version < 17976) { UpdateDataTable("CVE-2018-8440", vulnTable); }
-                        break;
-
-                    case "10586":
-                        if (version < 589) { UpdateDataTable("MS16-111", vulnTable); }
-                        if (version < 672)
-                        {
-                            UpdateDataTable("MS16-135", vulnTable);
-                            UpdateDataTable("MS16-138", vulnTable);
-                        }
-                        break;
-
-                    case "14393":
-                        if (version < 953)
-                        {
-                            UpdateDataTable("MS17-012", vulnTable);
-                            UpdateDataTable("MS17-017", vulnTable);
-                        }
-                        if (version < 1198) { UpdateDataTable("CVE-2017-0263", vulnTable); }
-                        if (version < 2248) { UpdateDataTable("CVE-2018-8897", vulnTable); }
-                        if (version < 2430) { UpdateDataTable("CVE-2018-0952", vulnTable); }
-                        if (version < 2485) { UpdateDataTable("CVE-2018-8440", vulnTable); }
-                        break;
-
-                    case "15063":
-                        if (version < 296) { UpdateDataTable("CVE-2017-0263", vulnTable); }
-                        if (version < 483) { UpdateDataTable("MS16-111", vulnTable); }
-                        if (version < 608)
-                        {
-                            UpdateDataTable("MS16-039", vulnTable);
-                            UpdateDataTable("MS16-123", vulnTable);
-                        }
-                        if (version < 1266) { UpdateDataTable("CVE-2018-0952", vulnTable); }
-                        if (version < 1324) { UpdateDataTable("CVE-2018-8440", vulnTable); }
-                        break;
-
-                    case "16299":
-                        if (version < 611) { UpdateDataTable("CVE-2018-0952", vulnTable); }
-                        if (version < 665) { UpdateDataTable("CVE-2018-8440", vulnTable); }
-                        break;
-
-                    case "17134":
-                        if (version < 48) { UpdateDataTable("CVE-2018-8897", vulnTable); }
-                        if (version < 228) { UpdateDataTable("CVE-2018-0952", vulnTable); }
-                        if (version < 285) { UpdateDataTable("CVE-2018-8440", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            NtoskrnlExe.Check(vulnerabilities, sysInfo);
 
             // win32k.sys
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\win32k.sys");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "6001":
-                        if (version < 18523) { UpdateDataTable("MS10-073", vulnTable); }
-                        break;
-
-                    case "6002":
-                        if (version < 18305) { UpdateDataTable("MS10-073", vulnTable); }
-                        if (version < 18739) { UpdateDataTable("MS13-005", vulnTable); }
-                        if (version < 18974) { UpdateDataTable("MS13-101", vulnTable); }
-                        if (version < 19372) { UpdateDataTable("MS15-051", vulnTable); }
-                        if (version < 19597) { UpdateDataTable("MS16-034", vulnTable); }
-                        break;
-
-                    case "7600":
-                        if (version < 16667) { UpdateDataTable("MS10-073", vulnTable); }
-                        if (version < 17017) { UpdateDataTable("MS12-042", vulnTable); }
-                        if (version < 17175) { UpdateDataTable("MS13-005", vulnTable); }
-                        break;
-
-                    case "9200":
-                        if (version < 16468) { UpdateDataTable("MS13-005", vulnTable); }
-                        if (version < 16758) { UpdateDataTable("MS13-101", vulnTable); }
-                        if (version < 17130) { UpdateDataTable("MS14-058", vulnTable); }
-                        if (version < 17343) { UpdateDataTable("MS15-051", vulnTable); }
-                        break;
-
-                    case "9600":
-                        if (version < 16457) { UpdateDataTable("MS13-101", vulnTable); }
-                        if (version < 17796) { UpdateDataTable("MS15-051", vulnTable); }
-                        if (version < 17353) { UpdateDataTable("MS14-058", vulnTable); }
-                        if (version < 18228) { UpdateDataTable("MS16-034", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            Win32kSys.Check(vulnerabilities, sysInfo);
 
             // winsrv.dll
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\winsrv.dll");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "6001":
-                        if (version < 18638) { UpdateDataTable("MS11-056", vulnTable); }
-                        break;
-
-                    case "6002":
-                        if (version < 18456) { UpdateDataTable("MS11-056", vulnTable); }
-                        break;
-
-                    case "7600":
-                        if (version < 16816) { UpdateDataTable("MS11-056", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
-
+            WinsrvDll.Check(vulnerabilities, sysInfo);
 
             // afd.sys
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\drivers\\afd.sys");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "6001":
-                        if (version < 18639) { UpdateDataTable("MS11-046", vulnTable); }
-                        break;
-
-                    case "6002":
-                        if (version < 18457) { UpdateDataTable("MS11-046", vulnTable); }
-                        break;
-
-                    case "7600":
-                        if (version < 16802) { UpdateDataTable("MS11-046", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            AfdSys.Check(vulnerabilities, sysInfo);
 
             // schedsvc.dll
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\schedsvc.dll");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "6001":
-                        if (version < 18551) { UpdateDataTable("MS10-092", vulnTable); }
-                        break;
-
-                    case "6002":
-                        if (version < 18342) { UpdateDataTable("MS10-092", vulnTable); }
-                        break;
-
-                    case "7600":
-                        if (version < 16699) { UpdateDataTable("MS10-092", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            SchedsvcDll.Check(vulnerabilities, sysInfo);
 
             // seclogon.dll
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\seclogon.dll");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "6002":
-                        if (version < 19598 && cpuCount > 1) { UpdateDataTable("MS16-032", vulnTable); }
-                        break;
-
-                    case "9600":
-                        if (version < 18230 && cpuCount > 1) { UpdateDataTable("MS16-032", vulnTable); }
-                        break;
-
-                    case "10240":
-                        if (version < 16724 && cpuCount > 1) { UpdateDataTable("MS16-032", vulnTable); }
-                        break;
-
-                    case "10586":
-                        if (version < 162 && cpuCount > 1) { UpdateDataTable("MS16-032", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            SeclogonDll.Check(vulnerabilities, sysInfo);
 
             // mrxdav.sys
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\drivers\\mrxdav.sys");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "6002":
-                        if (version < 19576) { UpdateDataTable("MS16-016", vulnTable); }
-                        break;
-
-                    case "9600":
-                        if (version < 18189) { UpdateDataTable("MS16-016", vulnTable); }
-                        break;
-
-                    case "10240":
-                        if (version < 16683) { UpdateDataTable("MS16-016", vulnTable); }
-                        break;
-
-                    case "10586":
-                        if (version < 103) { UpdateDataTable("MS16-016", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            MrxdavSys.Check(vulnerabilities, sysInfo);
 
             // rpcrt4.dll
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\rpcrt4.dll");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "6002":
-                        if (version < 19431) { UpdateDataTable("MS15-076", vulnTable); }
-                        break;
-
-                    case "9200":
-                        if (version < 17422) { UpdateDataTable("MS15-076", vulnTable); }
-                        break;
-
-                    case "9600":
-                        if (version < 17919) { UpdateDataTable("MS15-076", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            Rpcrt4Dll.Check(vulnerabilities, sysInfo);
 
             // atmfd.dll
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\atmfd.dll");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "9200":
-                        if (version < 243) { UpdateDataTable("MS15-078", vulnTable); }
-                        break;
-
-                    case "9600":
-                        if (version < 243) { UpdateDataTable("MS15-078", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            AtmfdDll.Check(vulnerabilities, sysInfo);
 
             // winload.exe
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\winload.exe");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "16299":
-                        if (version < 431) { UpdateDataTable("CVE-2018-8897", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            WinloadExe.Check(vulnerabilities, sysInfo);
 
             // win32kfull.sys
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\win32kfull.sys");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "10240":
-                        if (version < 16683) { UpdateDataTable("MS16-014", vulnTable); }
-                        if (version < 16724) { UpdateDataTable("MS16-034", vulnTable); }
-                        if (version < 16771) { UpdateDataTable("MS16-039", vulnTable); }
-                        break;
-
-                    case "10586":
-                        if (version < 103) { UpdateDataTable("MS16-014", vulnTable); }
-                        if (version < 162) { UpdateDataTable("MS16-034", vulnTable); }
-                        if (version < 212) { UpdateDataTable("MS16-039", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            Win32kfullSys.Check(vulnerabilities, sysInfo);
 
             // gdi32.dll
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\gdi32.dll");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "10240":
-                        if (version < 17319)
-                        {
-                            UpdateDataTable("MS17-012", vulnTable);
-                            UpdateDataTable("MS17-017", vulnTable);
-                        }
-                        if (version < 17394) { UpdateDataTable("CVE-2017-0263", vulnTable); }
-                        break;
-
-                    case "10586":
-                        if (version < 839)
-                        {
-                            UpdateDataTable("MS17-012", vulnTable);
-                            UpdateDataTable("MS17-017", vulnTable);
-                        }
-                        if (version < 916) { UpdateDataTable("CVE-2017-0263", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            Gdi32Dll.Check(vulnerabilities, sysInfo);
 
             // gdiplus.dll
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\gdiplus.dll");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "10240":
-                        if (version < 17146)
-                        {
-                            UpdateDataTable("MS16-101", vulnTable);
-                            UpdateDataTable("MS16-123", vulnTable);
-                            UpdateDataTable("MS16-125", vulnTable);
-                        }
-                        break;
-
-                    case "10586":
-                        if (version < 633)
-                        {
-                            UpdateDataTable("MS16-101", vulnTable);
-                            UpdateDataTable("MS16-123", vulnTable);
-                            UpdateDataTable("MS16-125", vulnTable);
-                        }
-                        break;
-                }
-            }
-            catch { }
+            GdiplusDll.Check(vulnerabilities, sysInfo);
 
             // gpprefcl.dll
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\gpprefcl.dll");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "10240":
-                        if (version < 16942) { UpdateDataTable("MS16-072", vulnTable); }
-                        break;
-
-                    case "10586":
-                        if (version < 420) { UpdateDataTable("MS16-072", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            GpprefclDll.Check(vulnerabilities, sysInfo);
 
             // pcadm.dll
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\pcadm.dll");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "10240":
-                        if (version < 17861) { UpdateDataTable("CVE-2018-8897", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            PcadmDll.Check(vulnerabilities, sysInfo);
 
             // coremessaging.dll
-
-            try
-            {
-                FileVersionInfo FileInfo = GetFileVersionInfo(winPath + "\\coremessaging.dll");
-                int version = FileInfo.ProductPrivatePart;
-
-                switch (osBuild)
-                {
-                    case "15063":
-                        if (version < 1088) { UpdateDataTable("CVE-2018-8897", vulnTable); }
-                        break;
-                }
-            }
-            catch { }
+            CoremessagingDll.Check(vulnerabilities, sysInfo);
 
             // and we're done... print results
-
-            int vulnCount = 0;
-
-            foreach (DataRow row in vulnTable.Rows)
-            {
-
-                if (row["Vulnerable"].ToString().Equals("True"))  // not sure if you have to do it like this...
-                {
-                    Console.WriteLine("  [*] Appears vulnerable to {0}", row["Name"]);
-                    Console.WriteLine("   [>] Description: {0}", row["Description"]);
-                    Console.WriteLine("   [>] Exploit: {0}", row["Exploit"]);
-                    Console.WriteLine("   [>] Notes: {0}", row["Notes"]);
-                    Console.WriteLine();
-
-                    vulnCount++;
-                }
-            }
-
-            if (vulnCount > 0)
-            {
-                Console.WriteLine(" [*] Finished. Found {0} vulns :)", vulnCount);
-            }
-            else
-            {
-                Console.WriteLine(" [*] Finished. Sorry, found {0} vulns :(", vulnCount);
-            }
+            vulnerabilities.ShowResults();
         }
     }
 }

--- a/Watson/Properties/AssemblyInfo.cs
+++ b/Watson/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -19,8 +18,6 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("a678dceb-6a5f-4ae9-b122-deecefd6a87b")]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/Watson/SuspectFiles/AfdSys.cs
+++ b/Watson/SuspectFiles/AfdSys.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class AfdSys
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\drivers\\afd.sys");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "6001":
+                        if (version < 18639)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS11-046");
+                        }
+
+                        break;
+
+                    case "6002":
+                        if (version < 18457)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS11-046");
+                        }
+
+                        break;
+
+                    case "7600":
+                        if (version < 16802)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS11-046");
+                        }
+
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+
+        }
+    }
+}

--- a/Watson/SuspectFiles/AtmfdDll.cs
+++ b/Watson/SuspectFiles/AtmfdDll.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class AtmfdDll
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\atmfd.dll");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "9200":
+                        if (version < 243)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS15-078");
+                        }
+                        break;
+
+                    case "9600":
+                        if (version < 243)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS15-078");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SuspectFiles/CoremessagingDll.cs
+++ b/Watson/SuspectFiles/CoremessagingDll.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class CoremessagingDll
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\coremessaging.dll");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "15063":
+                        if (version < 1088)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-8897");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+
+        }
+    }
+}

--- a/Watson/SuspectFiles/Gdi32Dll.cs
+++ b/Watson/SuspectFiles/Gdi32Dll.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class  Gdi32Dll
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\gdi32.dll");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "10240":
+                        if (version < 17319)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS17-012");
+                            vulnerabilities.SetAsVulnerable("MS17-017");
+                        }
+                        if (version < 17394)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2017-0263");
+                        }
+                        break;
+
+                    case "10586":
+                        if (version < 839)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS17-012");
+                            vulnerabilities.SetAsVulnerable("MS17-017");
+                        }
+                        if (version < 916)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2017-0263");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SuspectFiles/GdiplusDll.cs
+++ b/Watson/SuspectFiles/GdiplusDll.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class GdiplusDll
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\gdiplus.dll");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "10240":
+                        if (version < 17146)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-101");
+                            vulnerabilities.SetAsVulnerable("MS16-123");
+                            vulnerabilities.SetAsVulnerable("MS16-125");
+                        }
+                        break;
+
+                    case "10586":
+                        if (version < 633)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-101");
+                            vulnerabilities.SetAsVulnerable("MS16-123");
+                            vulnerabilities.SetAsVulnerable("MS16-125");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SuspectFiles/GpprefclDll.cs
+++ b/Watson/SuspectFiles/GpprefclDll.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class GpprefclDll
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\gpprefcl.dll");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "10240":
+                        if (version < 16942)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-072");
+                        }
+                        break;
+
+                    case "10586":
+                        if (version < 420)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-072");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SuspectFiles/MrxdavSys.cs
+++ b/Watson/SuspectFiles/MrxdavSys.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class MrxdavSys
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\drivers\\mrxdav.sys");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "6002":
+                        if (version < 19576)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-016");
+                        }
+                        break;
+
+                    case "9600":
+                        if (version < 18189)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-016");
+                        }
+                        break;
+
+                    case "10240":
+                        if (version < 16683)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-016");
+                        }
+                        break;
+
+                    case "10586":
+                        if (version < 103)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-016");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SuspectFiles/NtoskrnlExe.cs
+++ b/Watson/SuspectFiles/NtoskrnlExe.cs
@@ -1,0 +1,150 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class NtoskrnlExe
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\ntoskrnl.exe");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "6000":
+                        if (version < 16973)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS10-015");
+                        }
+                        break;
+
+                    case "6001":
+                        if (version < 18377)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS10-015");
+                        }
+                        break;
+
+                    case "6002":
+                        if (version < 18160)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS10-015");
+                        }
+                        break;
+
+                    case "10240":
+                        if (version < 17113)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-111");
+                        }
+                        if (version < 17184)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-135");
+                            vulnerabilities.SetAsVulnerable("MS16-138");
+                        }
+                        if (version < 17946)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-0952");
+                        }
+                        if (version < 17976)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-8440");
+                        }
+                        break;
+
+                    case "10586":
+                        if (version < 589)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-111");
+                        }
+                        if (version < 672)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-135");
+                            vulnerabilities.SetAsVulnerable("MS16-138");
+                        }
+                        break;
+
+                    case "14393":
+                        if (version < 953)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS17-012");
+                            vulnerabilities.SetAsVulnerable("MS17-017");
+                        }
+                        if (version < 1198)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2017-0263");
+                        }
+                        if (version < 2248)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-8897");
+                        }
+                        if (version < 2430)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-0952");
+                        }
+                        if (version < 2485)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-8440");
+                        }
+                        break;
+
+                    case "15063":
+                        if (version < 296)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2017-0263");
+                        }
+                        if (version < 483)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-111");
+                        }
+                        if (version < 608)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-039");
+                            vulnerabilities.SetAsVulnerable("MS16-123");
+                        }
+                        if (version < 1266)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-0952");
+                        }
+                        if (version < 1324)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-8440");
+                        }
+                        break;
+
+                    case "16299":
+                        if (version < 611)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-0952");
+                        }
+                        if (version < 665)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-8440");
+                        }
+                        break;
+
+                    case "17134":
+                        if (version < 48)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-8897");
+                        }
+                        if (version < 228)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-0952");
+                        }
+                        if (version < 285)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-8440");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+
+        }
+    }
+}

--- a/Watson/SuspectFiles/PcadmDll.cs
+++ b/Watson/SuspectFiles/PcadmDll.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class PcadmDll
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\pcadm.dll");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "10240":
+                        if (version < 17861)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-8897");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SuspectFiles/Rpcrt4Dll.cs
+++ b/Watson/SuspectFiles/Rpcrt4Dll.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class Rpcrt4Dll
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\rpcrt4.dll");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "6002":
+                        if (version < 19431)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS15-076");
+                        }
+                        break;
+
+                    case "9200":
+                        if (version < 17422)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS15-076");
+                        }
+                        break;
+
+                    case "9600":
+                        if (version < 17919)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS15-076");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SuspectFiles/SchedsvcDll.cs
+++ b/Watson/SuspectFiles/SchedsvcDll.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class SchedsvcDll
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\schedsvc.dll");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "6001":
+                        if (version < 18551)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS10-092");
+                        }
+                        break;
+
+                    case "6002":
+                        if (version < 18342)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS10-092");
+                        }
+                        break;
+
+                    case "7600":
+                        if (version < 16699)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS10-092");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SuspectFiles/SeclogonDll.cs
+++ b/Watson/SuspectFiles/SeclogonDll.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class SeclogonDll
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\seclogon.dll");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "6002":
+                        if (version < 19598 && sysInfo.CpuCount > 1)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-032");
+                        }
+                        break;
+
+                    case "9600":
+                        if (version < 18230 && sysInfo.CpuCount > 1)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-032");
+                        }
+                        break;
+
+                    case "10240":
+                        if (version < 16724 && sysInfo.CpuCount > 1)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-032");
+                        }
+                        break;
+
+                    case "10586":
+                        if (version < 162 && sysInfo.CpuCount > 1)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-032");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SuspectFiles/Win32kSys.cs
+++ b/Watson/SuspectFiles/Win32kSys.cs
@@ -1,0 +1,104 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class Win32kSys
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\win32k.sys");
+                switch (sysInfo.OsBuild)
+                {
+                    case "6001":
+                        if (version < 18523)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS10-073");
+                        }
+                        break;
+
+                    case "6002":
+                        if (version < 18305)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS10-073");
+                        }
+                        if (version < 18739)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS13-005");
+                        }
+                        if (version < 18974)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS13-101");
+                        }
+                        if (version < 19372)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS15-051");
+                        }
+                        if (version < 19597)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-034");
+                        }
+                        break;
+
+                    case "7600":
+                        if (version < 16667)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS10-073");
+                        }
+                        if (version < 17017)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS12-042");
+                        }
+                        if (version < 17175)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS13-005");
+                        }
+                        break;
+
+                    case "9200":
+                        if (version < 16468)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS13-005");
+                        }
+                        if (version < 16758)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS13-101");
+                        }
+                        if (version < 17130)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS14-058");
+                        }
+                        if (version < 17343)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS15-051");
+                        }
+                        break;
+
+                    case "9600":
+                        if (version < 16457)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS13-101");
+                        }
+                        if (version < 17796)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS15-051");
+                        }
+                        if (version < 17353)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS14-058");
+                        }
+                        if (version < 18228)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-034");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SuspectFiles/Win32kfullSys.cs
+++ b/Watson/SuspectFiles/Win32kfullSys.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class Win32kfullSys
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\win32kfull.sys");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "10240":
+                        if (version < 16683)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-014");
+                        }
+                        if (version < 16724)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-034");
+                        }
+                        if (version < 16771)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-039");
+                        }
+                        break;
+
+                    case "10586":
+                        if (version < 103)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-014");
+                        }
+                        if (version < 162)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-034");
+                        }
+                        if (version < 212)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS16-039");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SuspectFiles/WinloadExe.cs
+++ b/Watson/SuspectFiles/WinloadExe.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class WinloadExe
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\winload.exe");
+
+                switch (sysInfo.OsBuild)
+                {
+                    case "16299":
+                        if (version < 431)
+                        {
+                            vulnerabilities.SetAsVulnerable("CVE-2018-8897");
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SuspectFiles/WinsrvDll.cs
+++ b/Watson/SuspectFiles/WinsrvDll.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace Watson.SuspectFiles
+{
+    internal static class WinsrvDll
+    {
+        public static void Check(VulnerabilityCollection vulnerabilities, SystemInfo sysInfo)
+        {
+            try
+            {
+                int version = SystemInfoHelpers.GetFileVersionInfoProductPrivatePart(sysInfo.WinPath + "\\winsrv.dll");
+                switch (sysInfo.OsBuild)
+                {
+                    case "6001":
+                        if (version < 18638)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS11-056");
+                        }
+
+                        break;
+
+                    case "6002":
+                        if (version < 18456)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS11-056");
+                        }
+
+                        break;
+
+                    case "7600":
+                        if (version < 16816)
+                        {
+                            vulnerabilities.SetAsVulnerable("MS11-056");
+                        }
+
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                vulnerabilities.AddError(ex.Message);
+            }
+        }
+    }
+}

--- a/Watson/SystemInfo.cs
+++ b/Watson/SystemInfo.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace Watson
+{
+    public class SystemInfo
+    {
+        public string OsBuild { get; }
+
+        public UInt16 CpuAddrWidth { get; }
+
+        public int ProcIntPtr { get; }
+
+        public string WinPath { get; }
+
+        public int CpuCount { get; }
+
+        private SystemInfo(string osBuild, UInt16 cpuAddrWidth, int procIntPtr, string winPath, int cpuCount)
+        {
+            OsBuild = osBuild;
+            CpuAddrWidth = cpuAddrWidth;
+            ProcIntPtr = procIntPtr;
+            WinPath = winPath;
+            CpuCount = cpuCount;
+        }
+
+        public static SystemInfo Collect()
+        {
+            var osBuild = SystemInfoHelpers.GetOSBuildNumber();
+
+            var cpuAddrWidth = SystemInfoHelpers.GetCPUArchitecutre();
+
+            var procIntPtr = SystemInfoHelpers.GetProcessArchitecture();
+
+            var winPath = SystemInfoHelpers.GetWinPath(cpuAddrWidth, procIntPtr);
+
+            var cpuCount = SystemInfoHelpers.GetProcessorCoreCount();
+
+            return new SystemInfo(osBuild, cpuAddrWidth, procIntPtr, winPath, cpuCount);
+        }
+    }
+}

--- a/Watson/SystemInfoHelpers.cs
+++ b/Watson/SystemInfoHelpers.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Diagnostics;
+using System.Management;
+
+namespace Watson
+{
+    public static class SystemInfoHelpers
+    {
+        public static void PrintInfo(SystemInfo systemInfo)
+        {
+            Console.WriteLine(" [*] OS Build number: {0}", systemInfo.OsBuild);
+            Console.WriteLine(" [*] CPU Address Width: {0}", systemInfo.CpuAddrWidth);
+            Console.WriteLine(" [*] Process IntPtr Size: {0}", systemInfo.ProcIntPtr);
+            Console.WriteLine(" [*] Using Windows path: {0}", systemInfo.WinPath);
+        }
+
+        public static string GetOSBuildNumber()
+        {
+            var result = String.Empty;
+
+            var osData = new ManagementObjectSearcher("SELECT * FROM Win32_OperatingSystem");
+
+            foreach (ManagementObject os in osData.Get())
+            {
+                result = os["BuildNumber"].ToString();
+            }
+
+            return result;
+        }
+
+        public static int GetFileVersionInfoProductPrivatePart(string filePath) 
+            => FileVersionInfo.GetVersionInfo(filePath).ProductPrivatePart;
+
+        public static UInt16 GetCPUArchitecutre()
+        {
+            // bool result = System.Environment.Is64BitOperatingSystem;  // Not available in .NET <4
+
+            UInt16 result = 0;
+
+            var cpuData = new ManagementObjectSearcher("select AddressWidth from Win32_Processor");
+
+            foreach (ManagementObject cpu in cpuData.Get())
+            {
+                result = (UInt16)cpu["AddressWidth"];
+            }
+
+            return result;
+
+        }
+
+        public static int GetProcessArchitecture()
+        {
+            // bool result = System.Environment.Is64BitProcess;  // Not available in .NET <4
+
+            return IntPtr.Size;
+        }
+
+        public static int GetProcessorCoreCount() 
+            => Environment.ProcessorCount;
+
+        public static string GetWinPath(UInt16 cpuAddrWidth, int procIntPtr)
+        {
+            if ((cpuAddrWidth == 64 && procIntPtr == 8) || (cpuAddrWidth == 32 && procIntPtr == 4))
+            {
+                return "C:\\WINDOWS\\System32";
+            }
+            else
+            {
+                return "C:\\WINDOWS\\Sysnative";
+            }
+
+        }
+    }
+}

--- a/Watson/Vulnerability.cs
+++ b/Watson/Vulnerability.cs
@@ -1,0 +1,23 @@
+﻿namespace Watson
+{
+    public class Vulnerability
+    {
+        public string Name { get; }
+        public string Description { get; }
+        public string Exploit { get; }
+        public string Notes { get; }
+        public bool IsVulnerable { get; private set; }
+
+        public Vulnerability(string name, string description, string exploit, string notes = "None.")
+        {
+            Name = name;
+            Description = description;
+            Exploit = exploit;
+            Notes = notes;
+        }
+
+        public void SetAsVulnerable()
+            => IsVulnerable = true;
+
+    }
+}

--- a/Watson/VulnerabilityCollection.cs
+++ b/Watson/VulnerabilityCollection.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Watson
+{
+    public class VulnerabilityCollection
+    {
+        private readonly List<Vulnerability> _vulnerabilities;
+
+        private string _errors = "";
+
+        public VulnerabilityCollection()
+        {
+            _vulnerabilities = PopulateVulnerabilities();
+        }
+
+        public void SetAsVulnerable(string name) 
+            => _vulnerabilities.First(e => e.Name == name).SetAsVulnerable();
+
+        public void AddError(string errorMessage)
+            => _errors += "ERROR> " + errorMessage + Environment.NewLine;
+
+        public void ShowResults()
+        {
+            foreach (var vulnerability in _vulnerabilities.Where(i => i.IsVulnerable))
+            {
+                Console.WriteLine("  [*] Appears vulnerable to {0}", vulnerability.Name);
+                Console.WriteLine("   [>] Description: {0}", vulnerability.Description);
+                Console.WriteLine("   [>] Exploit: {0}", vulnerability.Exploit);
+                Console.WriteLine("   [>] Notes: {0}", vulnerability.Notes);
+                Console.WriteLine();
+            }
+
+            if (_vulnerabilities.Any(e => e.IsVulnerable))
+                Console.WriteLine(" [*] Finished. Found {0} vulns :)", _vulnerabilities.Count(i => i.IsVulnerable));
+            else
+                Console.WriteLine(" [*] Finished. Sorry, found 0 vulns :(");
+
+            // Output any errors found
+            Console.WriteLine(_errors);
+
+        }
+
+        private List<Vulnerability> PopulateVulnerabilities()
+        {
+            return new List<Vulnerability>(30)
+            {
+                new Vulnerability(name: "MS10-015",
+                    description: "Windows SYSTEM Escalation via KiTrap0D.",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms10_015_kitrap0d.rb"),
+
+                new Vulnerability(name: "MS10-073",
+                    description: "Kernel-mode drivers load unspecified keyboard layers improperly, which result in arbitrary code execution in the kernel.",
+                    exploit: "https://www.exploit-db.com/exploits/36327/"),
+
+                new Vulnerability(name: "MS10-092",
+                    description: "When processing task files, the Windows Task Scheduler only uses a CRC32 checksum to validate that the file has not been tampered with.Also, In a default configuration, normal users can read and write the task files that they have created.By modifying the task file and creating a CRC32 collision, an attacker can execute arbitrary commands with SYSTEM privileges.",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms10_092_schelevator.rb"),
+
+                new Vulnerability(name: "MS11-046",
+                    description: "The Ancillary Function Driver (AFD) in afd.sys does not properly validate user-mode input, which allows local users to elevate privileges.",
+                    exploit: "https://www.exploit-db.com/exploits/40564/"),
+
+                new Vulnerability(name: "MS11-080",
+                    description: "An EoP exists due to a flaw in the AfdJoinLeaf function of the afd.sys driver, allowing data overwrite in kernel space.",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb"),
+
+                new Vulnerability(name: "MS12-042",
+                    description: "An EoP exists due to the way the Windows User Mode Scheduler handles system requests, which can be exploited to execute arbitrary code in kernel mode.",
+                    exploit: "https://www.exploit-db.com/exploits/20861/"),
+
+                new Vulnerability(name: "MS13-005",
+                    description: "Due to a problem with isolating window broadcast messages in the Windows kernel, an attacker can broadcast commands from a lower Integrity Level process to a higher Integrity Level process, thereby effecting a privilege escalation.",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb"),
+
+                new Vulnerability(name: "MS13-053", description: "An EoP exists due to a kernel pool overflow in Win32k.",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms13_053_schlamperei.rb"),
+
+                new Vulnerability(name: "MS13-081",
+                    description: "An EoP exists in win32k.sys where under specific conditions TrackPopupMenuEx will pass a NULL pointer to the MNEndMenuState procedure.",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms13_081_track_popup_menu.rb"),
+
+                new Vulnerability(name: "MS14-058",
+                    description: "An EoP exists due to a NULL Pointer Dereference in win32k.sys, triggered through the use of TrackPopupMenu.",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms14_058_track_popup_menu.rb"),
+
+                new Vulnerability(name: "MS15-051",
+                    description: "An EoP exists due to improper object handling in the win32k.sys kernel mode driver.",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms15_051_client_copy_image.rb"),
+
+                new Vulnerability(name: "MS15-076",
+                    description: "Local DCOM DCE/RPC connections can be reflected back to a listening TCP socket allowing access to an NTLM authentication challenge for LocalSystem, which can be replayed to the local DCOM activation service to elevate privileges.",
+                    exploit: "https://www.exploit-db.com/exploits/37768/"),
+
+                new Vulnerability(name: "MS15-078",
+                    description: "An EoP exists due to a pool based buffer overflow in the atmfd.dll driver when parsing a malformed font.",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms15_078_atmfd_bof.rb"),
+
+                new Vulnerability(name: "MS16-014",
+                    description: "An EoP exists when the Windows kernel improperly handles objects in memory.",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms16_014_wmi_recv_notif.rb"),
+
+                new Vulnerability(name: "MS16-016",
+                    description: "An EoP exists in the Microsoft Web Distributed Authoring and Versioning (WebDAV) client when WebDAV improperly validates input.",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/ms16_016_webdav.rb"),
+
+                new Vulnerability(name: "MS16-032",
+                    description: "An EoP exists due to a lack of sanitization of standard handles in Windows' Secondary Logon Service.",
+                    exploit: "https://github.com/FuzzySecurity/PowerShell-Suite/blob/master/Invoke-MS16-032.ps1"),
+
+                new Vulnerability(name: "MS16-034",
+                    description: "An EoP exist when the Windows kernel-mode driver fails to properly handle objects in memory.",
+                    exploit: "https://github.com/SecWiki/windows-kernel-exploits/tree/master/MS16-034"),
+
+                new Vulnerability(name: "MS16-039",
+                    description: "An EoP exist when the Windows kernel-mode driver fails to properly handle objects in memory.",
+                    exploit: "https://www.exploit-db.com/exploits/44480/",
+                    notes: "Exploit is for Windows 7 x86."),
+
+                new Vulnerability(name: "MS16-072",
+                    description: "This vulnerability allows an attacker to create/modify local Administrator account through a fake Domain Controller by creating User Configuration Group Policies.",
+                    exploit: "https://www.exploit-db.com/exploits/40219/",
+                    notes: "Good luck with this one..."),
+
+                new Vulnerability(name: "MS16-111",
+                    description: "The NtLoadKeyEx system call allows an unprivileged user to load registry hives outside of the \\Registry\\A hidden attachment point which can be used to elevate privileges.",
+                    exploit: "https://www.exploit-db.com/exploits/40429/"),
+
+                new Vulnerability(name: "MS16-123",
+                    description: "The DFS Client driver and running by default insecurely creates and deletes drive letter symbolic links in the current user context, leading to EoP.",
+                    exploit: "https://www.exploit-db.com/exploits/40572/",
+                    notes: "Exploit requires weaponisation."),
+
+                new Vulnerability(name: "MS16-125",
+                    description: "The fix for CVE-2016-3231 is insufficient to prevent a normal user specifying an insecure agent path leading to arbitrary DLL loading at system privileges.",
+                    exploit: "https://www.exploit-db.com/exploits/40562/",
+                    notes: "Exploit requires a DLL to load."),
+
+                new Vulnerability(name: "MS16-135",
+                    description: "An EoP exists when the Windows kernel-mode driver fails to properly handle objects in memory.",
+                    exploit: "https://github.com/FuzzySecurity/PSKernel-Primitives/tree/master/Sample-Exploits/MS16-135"),
+
+                new Vulnerability(name: "MS16-138",
+                    description: "The VHDMP driver doesn’t safely create files related to Resilient Change Tracking leading to arbitrary file overwrites under user control, leading to EoP.",
+                    exploit: "https://www.exploit-db.com/exploits/40763/",
+                    notes: "Exploit requires weaponisation."),
+
+                new Vulnerability(name: "MS17-012",
+                    description: "When activating an object using the session moniker the DCOM activator doesn’t check if the current user has permission, allowing a user to start an arbitrary process in another logged on user's session.",
+                    exploit: "https://www.exploit-db.com/exploits/41607/"),
+
+                new Vulnerability(name: "MS17-017", description: "GDI Palette Objects EoP.",
+                    exploit: "https://www.exploit-db.com/exploits/42432/",
+                    notes: "Exploit is for Windows 7 x86 only"),
+
+                new Vulnerability(name: "CVE-2017-0263",
+                    description: "An EoP exists in Windows when the Windows kernel-mode driver fails to properly handle objects in memory.",
+                    exploit: "https://www.exploit-db.com/exploits/44478/",
+                    notes: "Exploit is for Windows 7 x86."),
+
+                new Vulnerability(name: "CVE-2018-8897",
+                    description: "An EoP exists when the Windows kernel fails to properly handle objects in memory.",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/mov_ss.rb",
+                    notes: "May not work on all hypervisors."),
+
+                new Vulnerability(name: "CVE-2018-0952",
+                    description: "An EoP exists when Diagnostics Hub Standard Collector allows file creation in arbitrary locations. ",
+                    exploit: "https://www.exploit-db.com/exploits/45244/"),
+
+                new Vulnerability(name: "CVE-2018-8440",
+                    description: "An EoP exists when Windows improperly handles calls to Advanced Local Procedure Call (ALPC).",
+                    exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/alpc_taskscheduler.rb")
+            };
+
+        }
+
+
+    }
+}

--- a/Watson/Watson.csproj
+++ b/Watson/Watson.csproj
@@ -38,12 +38,32 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Management" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SuspectFiles\AfdSys.cs" />
+    <Compile Include="SuspectFiles\AtmfdDll.cs" />
+    <Compile Include="SuspectFiles\CoremessagingDll.cs" />
+    <Compile Include="SuspectFiles\Gdi32Dll.cs" />
+    <Compile Include="SuspectFiles\GdiplusDll.cs" />
+    <Compile Include="SuspectFiles\GpprefclDll.cs" />
+    <Compile Include="SuspectFiles\MrxdavSys.cs" />
+    <Compile Include="SuspectFiles\NtoskrnlExe.cs" />
+    <Compile Include="SuspectFiles\PcadmDll.cs" />
+    <Compile Include="SuspectFiles\Rpcrt4Dll.cs" />
+    <Compile Include="SuspectFiles\SchedsvcDll.cs" />
+    <Compile Include="SuspectFiles\SeclogonDll.cs" />
+    <Compile Include="SuspectFiles\Win32kfullSys.cs" />
+    <Compile Include="SuspectFiles\Win32kSys.cs" />
+    <Compile Include="SuspectFiles\WinloadExe.cs" />
+    <Compile Include="SuspectFiles\WinsrvDll.cs" />
+    <Compile Include="VulnerabilityCollection.cs" />
+    <Compile Include="Vulnerability.cs" />
+    <Compile Include="SystemInfoHelpers.cs" />
+    <Compile Include="Info.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SystemInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
### Why these changes?:
The `program.cs` class is a bit of a monster!
The logic contained in the warren of case blocks is difficult to read and will be tricky to maintain going forward.

### What's changed - in brief:
I've pulled out the code from each `if` branch into its own class. 
Used a collection of `Vulnerability` types rather than a `DataSet`.
Displays errors/exceptions instead of eating them.

### Why are these changes worth including?:
The codebase is now simpler and easier to understand and maintain; with each unit of functionality living in its own specific, focused class.

### What's changed - in detail:
As mentioned, the big change was pulling out the code from each case block in `program.cs` and moving each part into its own object.  **The code was not changed - only moved.**

The new Classes are found in the `/SuspectFiles` folder and are named after the system files that they `Check()`.

`PopulateVulnerabilities()` in `VulnerabilityCollection.cs` contains the details from the previous `DataSet` version.

`VulnerabilityCollection.cs` also builds a string containing any errors encountered during the checks, and will display these, along with the results, when `ShowResults()` is called.

I have also pulled out the info/logo code into a separate file `Info.cs` - just to clean things up a bit more. 

### What hasn't changed:
The version number.
The logic/code that was within the `case` blocks in the `program.cs` file