### PR TITLE
Fixed: Can't Run on System with only .Net 2.0 [Issue 3]

### DIFF
--- a/Watson/VulnerabilityCollection.cs
+++ b/Watson/VulnerabilityCollection.cs
@@ -1,50 +1,58 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Watson
 {
     public class VulnerabilityCollection
     {
-        private readonly List<Vulnerability> _vulnerabilities;
+        private const int NUMBER_OF_VULNERABILITES = 30;
+
+        // Key: Name - Value: Vulnerability
+        private readonly Dictionary<string, Vulnerability> _vulnerabilities = new Dictionary<string, Vulnerability>(NUMBER_OF_VULNERABILITES);
 
         private string _errors = "";
 
         public VulnerabilityCollection()
         {
-            _vulnerabilities = PopulateVulnerabilities();
+            PopulateVulnerabilities();
         }
 
         public void SetAsVulnerable(string name) 
-            => _vulnerabilities.First(e => e.Name == name).SetAsVulnerable();
+            => _vulnerabilities[name].SetAsVulnerable();
+
 
         public void AddError(string errorMessage)
             => _errors += "ERROR> " + errorMessage + Environment.NewLine;
 
         public void ShowResults()
         {
-            foreach (var vulnerability in _vulnerabilities.Where(i => i.IsVulnerable))
+            int vulnerabilityCount = 0;
+            foreach (var vulnerability in _vulnerabilities.Values)
             {
-                Console.WriteLine("  [*] Appears vulnerable to {0}", vulnerability.Name);
-                Console.WriteLine("   [>] Description: {0}", vulnerability.Description);
-                Console.WriteLine("   [>] Exploit: {0}", vulnerability.Exploit);
-                Console.WriteLine("   [>] Notes: {0}", vulnerability.Notes);
-                Console.WriteLine();
+                if (vulnerability.IsVulnerable)
+                {
+                    Console.WriteLine("  [*] Appears vulnerable to {0}", vulnerability.Name);
+                    Console.WriteLine("   [>] Description: {0}", vulnerability.Description);
+                    Console.WriteLine("   [>] Exploit: {0}", vulnerability.Exploit);
+                    Console.WriteLine("   [>] Notes: {0}", vulnerability.Notes);
+                    Console.WriteLine();
+                    vulnerabilityCount++;
+                }
             }
 
-            if (_vulnerabilities.Any(e => e.IsVulnerable))
-                Console.WriteLine(" [*] Finished. Found {0} vulns :)", _vulnerabilities.Count(i => i.IsVulnerable));
+            if (vulnerabilityCount != 0)
+                Console.WriteLine(" [*] Finished. Found {0} vulns :)", vulnerabilityCount);
             else
                 Console.WriteLine(" [*] Finished. Sorry, found 0 vulns :(");
 
             // Output any errors found
             Console.WriteLine(_errors);
-
         }
 
-        private List<Vulnerability> PopulateVulnerabilities()
+        private void PopulateVulnerabilities()
         {
-            return new List<Vulnerability>(30)
+            // populate a list
+            var vulnList= new List<Vulnerability>(NUMBER_OF_VULNERABILITES)
             {
                 new Vulnerability(name: "MS10-015",
                     description: "Windows SYSTEM Escalation via KiTrap0D.",
@@ -150,7 +158,8 @@ namespace Watson
                     description: "When activating an object using the session moniker the DCOM activator doesn’t check if the current user has permission, allowing a user to start an arbitrary process in another logged on user's session.",
                     exploit: "https://www.exploit-db.com/exploits/41607/"),
 
-                new Vulnerability(name: "MS17-017", description: "GDI Palette Objects EoP.",
+                new Vulnerability(name: "MS17-017", 
+                    description: "GDI Palette Objects EoP.",
                     exploit: "https://www.exploit-db.com/exploits/42432/",
                     notes: "Exploit is for Windows 7 x86 only"),
 
@@ -173,6 +182,9 @@ namespace Watson
                     exploit: "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/alpc_taskscheduler.rb")
             };
 
+            // use the list to populate the dictionary to prevent having to type the key (Name) out again
+            foreach (var vulnerability in vulnList)
+                _vulnerabilities.Add(vulnerability.Name, vulnerability);
         }
 
 


### PR DESCRIPTION
This addresses the issues found in Issue https://github.com/rasta-mouse/Watson/issues/3

**Changes**:
Removed LINQ as it requires .Net > 2.0
Moved from a `List<>` to a `Dictionary<>` to store the `Vulnerability` objects
