### PR TITLE
Added reference to weaponized exploit for CVE-2019-1405

### DIFF
--- a/Watson/VulnerabilityCollection.cs
+++ b/Watson/VulnerabilityCollection.cs
@@ -82,7 +82,7 @@ namespace Watson
 
                 new Vulnerability(
                     id: "CVE-2019-1405",
-                    exploits: new string[] { "https://www.nccgroup.trust/uk/about-us/newsroom-and-events/blogs/2019/november/cve-2019-1405-and-cve-2019-1322-elevation-to-system-via-the-upnp-device-host-service-and-the-update-orchestrator-service/" }
+                    exploits: new string[] { "https://www.nccgroup.trust/uk/about-us/newsroom-and-events/blogs/2019/november/cve-2019-1405-and-cve-2019-1322-elevation-to-system-via-the-upnp-device-host-service-and-the-update-orchestrator-service/", "https://github.com/apt69/COMahawk" }
                     )
             };
 


### PR DESCRIPTION
For CVE-2019-1405, there is a working exploit at https://github.com/apt69/COMahawk. I added a reference.